### PR TITLE
Fixing gotm version

### DIFF
--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,10 +1,9 @@
 
 git clone https://github.com/fabm-model/fabm.git
-git clone https://github.com/gotm-model/code.git gotm
-cd gotm && git submodule update --init --recursive && cd ..
+git clone --recursive https://github.com/gotm-model/code.git -b v6.0 gotm
 
 mkdir build_pyfabm && cd build_pyfabm
-cmake ../fabm/src/drivers/python -DFABM_ERSEM_BASE=.. -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX 
+cmake ../fabm/src/drivers/python -DFABM_ERSEM_BASE=$SRC_DIR -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX
 # This makes sure pyfabm is built in the correct enviroment
 # Will be changed once pyfabm install is updated.
 sed -i -e 's/--user//g' cmake_install.cmake
@@ -13,13 +12,13 @@ make install DESTDIR=$PREFIX
 cd ..
 
 mkdir build_0d && cd build_0d
-cmake -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX ../fabm/src/drivers/0d -DGOTM_BASE=../gotm -DFABM_ERSEM_BASE=..
+cmake -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX ../fabm/src/drivers/0d -DGOTM_BASE=../gotm -DFABM_ERSEM_BASE=$SRC_DIR
 make -j${CPU_COUNT}
 make install
 cd ..
 
 mkdir build_gotm && cd build_gotm
-cmake -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX ../gotm -DFABM_BASE=../fabm -DFABM_ERSEM_BASE=..
+cmake -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX ../gotm -DFABM_BASE=../fabm -DFABM_ERSEM_BASE=$SRC_DIR
 make -j${CPU_COUNT}
 make install
 cd ..

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -4,8 +4,7 @@ package:
   version: 20.10
 
 source:
-  path: ..
-
+  git_url: https://github.com/pmlmodelling/ersem.git
 
 requirements:
   build:


### PR DESCRIPTION
Fixes `gotm` version and uses `master` branch from `ersem`.

Check, via `gotm -v` that the version are set correctly 