### PR TITLE
Adding read the docs yaml config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,20 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  builder: html
+  configuration: doc/source/conf.py
+
+# Optional build format
+formats:
+   - pdf
+
+python:
+  version: 3.8
+  install:
+  - requirements: docs/requirements.txt


### PR DESCRIPTION
Fixes #6 

Adds read the docs yaml file configuration. 

Tests:

1. Check that the yaml file has the correct configuration setup for read the docs