### PR TITLE
Docs build badge

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: html
-  configuration: doc/source/conf.py
+  configuration: docs/source/conf.py
 
 # Optional build format
 formats:


### PR DESCRIPTION
Fixes #12 

Fixing typo in read the docs yaml file

Test:
1. Check build worked in https://readthedocs.org/projects/ersem/builds/