### PR TITLE
Update troubleshooting link in GOTM installation instructions

### DIFF
--- a/docs/source/developers/gotm-dev.rst
+++ b/docs/source/developers/gotm-dev.rst
@@ -19,8 +19,7 @@ To install GOTM-FABM-ERSEM, we suggest you use the following script below
     :linenos:
 
 
-If you experience NetCDF issues when running ``make install``, see `tips
-and tricks/troubleshooting <#tips-and-trickstroubleshooting>`__.
+If you experience NetCDF issues when running ``make install``, see :ref:`trouble`.
 
 Now you should have a GOTM executable with FABM and ERSEM support at
 ``~/local/gotm/bin/gotm``.


### PR DESCRIPTION
#### Description of Work

Fixes #96 

Updates the broken troubleshooting link for the GOTM developers installation instructions.

#### Testing Instructions

1. Check that the updated link works correctly, the docs can be found [here](https://ersem--97.org.readthedocs.build/en/97/developers/gotm-dev.html)

