### PR TITLE
moved getting om_cal only if ISWCAL not equal to 0

### DIFF
--- a/src/benthic_calcite.F90
+++ b/src/benthic_calcite.F90
@@ -82,13 +82,14 @@ contains
       _HORIZONTAL_LOOP_BEGIN_
 
          _GET_HORIZONTAL_(self%id_c, bL2c)
-         _GET_(self%id_om_cal, om_cal)
 
          if (self%iswcal==0) then  ! NB select case would be cleaner but makes vectorization impossible for ifort 14
             fdiss = 0._rk
          elseif (self%iswcal==1) then
+            _GET_(self%id_om_cal, om_cal)
             fdiss = (max(1._rk-om_cal,0._rk))**self%ndiss
          else
+            _GET_(self%id_om_cal, om_cal)
             fdiss = max(0._rk,(1._rk-om_cal)/(1._rk-om_cal+self%KcalomX))
          end if
 


### PR DESCRIPTION
when ISWCAL=0 the dependency is not defined (because is not needed)

#### Description of Work

Fixes

#### Testing Instructions

1. raise atmospheric pCO2 to 2000 (as the difference is noticed only for low O3_om_cal)
2. run GOTM-ERSEM with normal fabm.yaml
3. run GOTM-ERSEM setting ISWCAL to 0, set new parameter fdiss to the same value of fdissmin, comment definitions of parameters fdissmax, ndiss, fidssmin and the coupling to O3/om_cal
4. compare the result  (run with ISWCAL = 0 has higher bL2_c)

