### PR TITLE
Fixing github tests badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Tests](https://github.com/pmlmodelling/ersem/workflows/build-ersem/badge.svg) 
+![Tests](https://img.shields.io/github/actions/workflow/status/pmlmodelling/ersem/ersem.yml?label=tests&style=flat-square) 
 [![Documentation Status](https://readthedocs.org/projects/ersem/badge/?version=latest)](https://ersem.readthedocs.io/en/latest/?badge=latest)
 
 # ERSEM


### PR DESCRIPTION
#### Description of Work

Fixes #125 

Updates the test badge in the readme

#### Testing Instructions

1. Change branch on the website to `125_test_badge` and check the test looks like this 
![image](https://github.com/pmlmodelling/ersem/assets/15614849/10d9cc62-0c8e-4c92-89fe-e4b2de96ec1f)


