### PR TITLE
Remove unused variable and parameter call for iswBlimX

### DIFF
--- a/src/bacteria_docdyn.F90
+++ b/src/bacteria_docdyn.F90
@@ -30,7 +30,6 @@ module ersem_bacteria_docdyn
       type (type_diagnostic_variable_id) :: id_minn,id_minp
       ! Parameters
       integer  :: nRP
-      integer  :: iswBlimX
       real(rk) :: q10B1X,chdB1oX
       real(rk) :: chB1nX,chB1pX
       real(rk) :: sdB1X
@@ -74,7 +73,6 @@ contains
 !EOP
 !-----------------------------------------------------------------------
 !BOC
-      call self%get_parameter(self%iswBlimX,'iswBlim', '',           'nutrient limitation (1: minimum of inorganic and organic availability, 2: additive availability)', minimum=1, maximum=2)
       call self%get_parameter(self%q10B1X,  'q10',     '-',          'Q_10 temperature coefficient')
       call self%get_parameter(self%chdB1oX, 'chdo',    '-',          'Michaelis-Menten constant for oxygen limitation')
       call self%get_parameter(self%chB1nX,  'chn',     'mmol N/m^3', 'Michaelis-Menten constant for nitrate limitation')

--- a/testcases/ersem-15.06/fabm-ersem-15.06-L4-ben-docdyn-iop-denit.yaml
+++ b/testcases/ersem-15.06/fabm-ersem-15.06-L4-ben-docdyn-iop-denit.yaml
@@ -215,7 +215,6 @@ instances:
     long_name: bacteria
     model: ersem/bacteria_docdyn
     parameters:
-      iswBlim: 2                                           # nutrient limitation (1: minimum of inorganic and organic availability, 2: additive availability)
       q10: 2.0                                             # Q_10 temperature coefficient (-)
       chdo: 0.31                                           # Michaelis-Menten constant for oxygen limitation (-)
       chn: 0.5                                             # Michaelis-Menten constant for nitrate limitation (mmol N/m^3)

--- a/testcases/ersem-15.06/fabm-ersem-15.06-L4-ben-docdyn-iop-n2o.yaml
+++ b/testcases/ersem-15.06/fabm-ersem-15.06-L4-ben-docdyn-iop-n2o.yaml
@@ -213,7 +213,6 @@ instances:
     long_name: bacteria
     model: ersem/bacteria_docdyn
     parameters:
-      iswBlim: 2                                           # nutrient limitation (1: minimum of inorganic and organic availability, 2: additive availability)
       q10: 2.0                                             # Q_10 temperature coefficient (-)
       chdo: 0.31                                           # Michaelis-Menten constant for oxygen limitation (-)
       chn: 0.5                                             # Michaelis-Menten constant for nitrate limitation (mmol N/m^3)

--- a/testcases/ersem-15.06/fabm-ersem-15.06-L4-ben-docdyn-iop.yaml
+++ b/testcases/ersem-15.06/fabm-ersem-15.06-L4-ben-docdyn-iop.yaml
@@ -206,7 +206,6 @@ instances:
     long_name: bacteria
     model: ersem/bacteria_docdyn
     parameters:
-      iswBlim: 2                                           # nutrient limitation (1: minimum of inorganic and organic availability, 2: additive availability)
       q10: 2.0                                             # Q_10 temperature coefficient (-)
       chdo: 0.31                                           # Michaelis-Menten constant for oxygen limitation (-)
       chn: 0.5                                             # Michaelis-Menten constant for nitrate limitation (mmol N/m^3)

--- a/testcases/ersem-15.06/fabm-ersem-15.06-L4-noben-docdyn-iop.yaml
+++ b/testcases/ersem-15.06/fabm-ersem-15.06-L4-noben-docdyn-iop.yaml
@@ -210,7 +210,6 @@ instances:
     long_name: bacteria
     model: ersem/bacteria_docdyn
     parameters:
-      iswBlim: 2                                          # nutrient limitation (1: minimum of inorganic and organic availability, 2: additive availability)
       q10: 2.0                                            # Q_10 temperature coefficient (-)
       chdo: 0.31                                          # Michaelis-Menten constant for oxygen limitation (-)
       chn: 0.5                                            # Michaelis-Menten constant for nitrate limitation (mmol N/m^3)

--- a/testcases/fabm-ersem-26.02-dvm-n2o.yaml
+++ b/testcases/fabm-ersem-26.02-dvm-n2o.yaml
@@ -207,7 +207,6 @@ instances:
     long_name: bacteria
     model: ersem/bacteria_docdyn
     parameters:
-      iswBlim: 2                                           # nutrient limitation (1: minimum of inorganic and organic availability, 2: additive availability)
       q10: 2.0                                             # Q_10 temperature coefficient (-)
       chdo: 0.31                                           # Michaelis-Menten constant for oxygen limitation (-)
       chn: 0.5                                             # Michaelis-Menten constant for nitrate limitation (mmol N/m^3)

--- a/testcases/fabm-ersem-26.02-dvm.yaml
+++ b/testcases/fabm-ersem-26.02-dvm.yaml
@@ -200,7 +200,6 @@ instances:
     long_name: bacteria
     model: ersem/bacteria_docdyn
     parameters:
-      iswBlim: 2                                           # nutrient limitation (1: minimum of inorganic and organic availability, 2: additive availability)
       q10: 2.0                                             # Q_10 temperature coefficient (-)
       chdo: 0.31                                           # Michaelis-Menten constant for oxygen limitation (-)
       chn: 0.5                                             # Michaelis-Menten constant for nitrate limitation (mmol N/m^3)

--- a/testcases/fabm-ersem.yaml.template
+++ b/testcases/fabm-ersem.yaml.template
@@ -243,7 +243,6 @@ instances:
     long_name: bacteria
     model: ersem/bacteria
     parameters:
-      iswBlim: $iswBlimX
       q10: $q10B1X
       chdo: $chdB1oX
       chn: $chB1nX


### PR DESCRIPTION
Removed unused variable 'iswBlimX' and its parameter call.

#### Description of Work

Fixes -removed 'iswBlimX

#### Testing Instructions

1. Check compiles and runs
2.
3.

